### PR TITLE
pip 23.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,3 +5,5 @@ $PYTHON setup.py install --single-version-externally-managed --record record.txt
 cd $PREFIX/bin
 rm -f pip2* pip3*
 rm -f $SP_DIR/__pycache__/pkg_res*
+# Remove all bundled .exe files courtesy of distlib.
+rm -f $SP_DIR/pip/_vendor/distlib/*.exe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "22.3.1" %}
+{% set version = "23.0" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
-  sha256: 65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38
+  sha256: aee438284e82c8def684b0bcc50b1f6ed5e941af97fa940e83e2e8ef1a59da9b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "23.0" %}
+{% set version = "23.0.1" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
-  sha256: aee438284e82c8def684b0bcc50b1f6ed5e941af97fa940e83e2e8ef1a59da9b
+  sha256: cd015ea1bfb0fcef59d8a286c1f8bebcb983f6317719d415dc5351efb7cd7024
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** []()

**The upstream data:**
Changelog:  https://pip.pypa.io/en/stable/news/
[Diff between the latest and previous upstream releases](https://github.com/pypa/pip/compare/22.3.1...23.0.1)
Requirements:
 * setup.cfg:  https://github.com/pypa/pip/blob/23.0.1/setup.cfg
 * setup.py:  https://github.com/pypa/pip/blob/23.0.1/setup.py
 * pyproject.toml:  https://github.com/pypa/pip/blob/23.0.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 23.0
 * Release on PyPi:
    * version: 23.0
    * date: 2023-01-30T23:10:56
* [PyPi history](https://pypi.org/project/pip/#history)
 * Popularity: 
    * 3 months downloads: 24134033.0
    * All time:  66741387 downloads -  pip  23.0  PyPA recommended tool for installing Python packages  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    setuptools
setuptools
6. - [ ] Verify if the package needs `wheel`
    wheel
wheel
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/pip-feedstock/recipe/meta.yaml
Dependencies: ['setuptools', 'wheel', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pip-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pip-feedstock/tree/23.0.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pip)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pip-feedstock/compare/main...AnacondaRecipes:23.0.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pip-feedstock/compare/master...AnacondaRecipes:23.0.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/pip-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.


</details>


```
git clone -b 23.0 git@github.com:AnacondaRecipes/pip-feedstock.git
```
