### PR TITLE
Remove jjhelmus from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @jjhelmus @mingwandroid @msarahan @ocefpaf @pelson
+* @jakirkham @mingwandroid @msarahan @ocefpaf @pelson


### PR DESCRIPTION
I'm being pulled into reviews because my account in included in this file, e.g #24.

The CODEOWNERS file is a artifact from conda-forge that has not need synced for some time.  
I removed myself from this file in the upstream repository in https://github.com/conda-forge/pip-feedstock/commit/9afa240e80ef8bd81872e5f468293479db1ff071.  

