### PR TITLE
Update to 24.1.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,5 @@
-%PYTHON% setup.py install --single-version-externally-managed --record record.txt
+set PYTHONPATH=".\src"
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
 if errorlevel 1 exit 1
 
 cd %SCRIPTS%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,10 @@
-set PYTHONPATH=".\src"
-%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+if "%BOOTSTRAP_FROM_WHL%"=="yes" (
+    set PYTHONPATH=".\pip-%PKG_VERSION%-py3-none-any.whl"
+    %PYTHON% -m pip install --no-cache-dir --no-index --no-index --find-links . pip
+) else (
+    set PYTHONPATH=".\src"
+    %PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+)
 if errorlevel 1 exit 1
 
 cd %SCRIPTS%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# use the pip source to install itself
-PYTHONPATH="./src" $PYTHON -m pip install . --no-deps --no-build-isolation -vv
+if [[ ${BOOTSTRAP_FROM_WHL} == yes ]]; then
+    # use the pip wheel to install itself
+    export PYTHONPATH='./pip-${PKG_VERSION}-py3-none-any.whl'
+    $PYTHON -m pip install --no-cache-dir --no-index --no-index --find-links . pip
+else
+    # use the pip source to install itself
+    export PYTHONPATH="./src"
+    $PYTHON -m pip install . --no-deps --no-build-isolation -vv
+fi
+
 
 cd $PREFIX/bin
 rm -f pip2* pip3*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-$PYTHON setup.py install --single-version-externally-managed --record record.txt
+# use the pip source to install itself
+PYTHONPATH="./src" $PYTHON -m pip install . --no-deps --no-build-isolation -vv
 
 cd $PREFIX/bin
 rm -f pip2* pip3*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   disable_pip: true
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   entry_points:
     - pip = pip._internal.cli.main:main
     - pip3 = pip._internal.cli.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    - setuptools
-    - wheel
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "24.0" %}
+{% set version = "24.1.2" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
-  sha256: ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2
+  sha256: e5458a0b89f2755e0ee8c0c77613fe5273e05f337907874d64f13171a898a7ff
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,9 @@
 {% set version = "24.1.2" %}
 
+# When bootstrapping a new Python version build pip from a wheel.
+# Otherwise build from the source distribution.
+{% set bootstrap = "no" %}
+
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 
 package:
@@ -7,8 +11,14 @@ package:
   version: {{ version }}
 
 source:
+  {% if bootstrap != "yes" %}
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
   sha256: e5458a0b89f2755e0ee8c0c77613fe5273e05f337907874d64f13171a898a7ff
+  {% else %}
+  url: https://files.pythonhosted.org/packages/py3/p/pip/pip-{{ version }}-py3-none-any.whl
+  sha256: 7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247
+  {% endif %}
+
 
 build:
   number: 0
@@ -17,12 +27,16 @@ build:
   entry_points:
     - pip = pip._internal.cli.main:main
     - pip3 = pip._internal.cli.main:main
+  script_env:
+    - BOOTSTRAP_FROM_WHL={{ bootstrap }}
 
 requirements:
   host:
     - python
+    {% if bootstrap != "yes" %}
     - setuptools >=67.6.1
     - wheel
+    {% endif %}
   run:
     - python
 


### PR DESCRIPTION
pip 24.1.2

**Destination channel:** defaults

### Links

- [PKG-5148](https://anaconda.atlassian.net/browse/PKG-5148) 
- [Upstream repository](https://github.com/pypa/pip/)
- [Upstream changelog/diff](https://pip.pypa.io/en/stable/news/)
- Relevant dependency PRs:

### Explanation of changes:

- Update to version 24.1.2 from 24.0.
- Bump minimum Python version to 3.8. Python 3.7 support was dropped by upstream in the 24.1b1 release.
- Use the pip source to install itself. This is needed as `setup.py`was removed in version 24.1b1.
- Remove the run requirements on `setuptools` and `wheel`. These are not needed at runtime and are not installed when `ensurepip` is run in CPython. 


[PKG-5148]: https://anaconda.atlassian.net/browse/PKG-5148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ