### PR TITLE
V24.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,5 @@
-%PYTHON% setup.py install --single-version-externally-managed --record record.txt
+set PYTHONPATH=".\src"
+%PYTHON% -m pip install . -vv
 if errorlevel 1 exit 1
 
 cd %SCRIPTS%
@@ -6,5 +7,4 @@ del *.exe
 del *.exe.manifest
 del pip2*
 del pip3*
-
 :: del %SP_DIR%\__pycache__\pkg_res*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-$PYTHON setup.py install --single-version-externally-managed --record record.txt
+# use the pip source to install itself
+PYTHONPATH="./src" $PYTHON -m pip install . -vv
 
 cd $PREFIX/bin
 rm -f pip2* pip3*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "24.0" %}
+{% set version = "24.2" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
-  sha256: ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2
+  sha256: 5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
 
 build:
   number: 0


### PR DESCRIPTION
pip 24.2

**Destination channel:** defaults

### Links

- [PKG-5148](https://anaconda.atlassian.net/browse/PKG-5148) 
- [Upstream repository](https://github.com/pypa/pip)
- [Upstream changelog/diff](https://pip.pypa.io/en/stable/news/#v24-2)
- Relevant dependency PRs:

### Explanation of changes:

- Update to version 24.2
- Use the pip source to install itself. Note that setup.py was removed in version 24.1 so is no longer an option. 
- Tracks similar changes in conda-forge: 
    - conda-forge/pip-feedstock#121 
    - conda-forge/pip-feedstock#125

