### PR TITLE
Bumping pip-feedstock to version 25.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+with_setuptools_wheel:
+  - true
+  - false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,28 +6,33 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pip/pip-{{ version }}.tar.gz
   sha256: 272bdd1289f80165e9070a4f881e8f9e1001bbb50378561d1af20e49bf5a2200
 
 build:
+  noarch: python
   number: 0
   disable_pip: true
-  skip: true  # [py<38]
   entry_points:
     - pip = pip._internal.cli.main:main
     - pip3 = pip._internal.cli.main:main
 
 requirements:
   host:
-    - python
-    - setuptools >=67.6.1
-    - wheel
-  run:
-    - python
+    - python >=3.13.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.13.0a0               # [with_setuptools_wheel]
     - setuptools
     - wheel
+  run:
+    - python >=3.13.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.13.0a0               # [with_setuptools_wheel]
+    - setuptools                           # [with_setuptools_wheel]
+    - wheel                                # [with_setuptools_wheel]
 
 test:
+  requires:
+    - python 3.9                           # [with_setuptools_wheel]
+    - python 3.13.0                        # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
-{% set version = "25.0" %}
+{% set version = "25.1" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
-
 package:
   name: pip
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/p/pip/pip-{{ version }}.tar.gz
-  sha256: 8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b
+  sha256: 272bdd1289f80165e9070a4f881e8f9e1001bbb50378561d1af20e49bf5a2200
 
 build:
   number: 0
   disable_pip: true
-  skip: True  # [py<38]
+  skip: true  # [py<38]
   entry_points:
     - pip = pip._internal.cli.main:main
     - pip3 = pip._internal.cli.main:main
@@ -42,8 +41,8 @@ about:
   license_file: LICENSE.txt
   summary: PyPA recommended tool for installing Python packages
   description: |
-    pip is the package installer for Python. 
-    You can use pip to install packages from the Python Package 
+    pip is the package installer for Python.
+    You can use pip to install packages from the Python Package
     Index and other indexes.
   doc_url: https://pip.pypa.io
   dev_url: https://github.com/pypa/pip


### PR DESCRIPTION
- Moving to noarch - this will facilitate next python updates.
- Follow conda-forge on removing the run dependencies on setuptools and wheel, which have not been required for a while. Our linter has asked us for the past two years to add setuptools to the host section, so I don't expect additional work on feedstocks from this change.

https://github.com/pypa/pip/tree/25.1