### PR TITLE
pip 25.1 b1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,5 +6,3 @@ PYTHONPATH="./src" $PYTHON -m pip install --no-deps --no-build-isolation . -vv
 cd $PREFIX/bin
 rm -f pip2* pip3*
 rm -f $SP_DIR/__pycache__/pkg_res*
-# Remove all bundled .exe files courtesy of distlib.
-rm -f $SP_DIR/pip/_vendor/distlib/*.exe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main


### PR DESCRIPTION
- Moving to noarch - this will facilitate next python updates.
- Follow conda-forge on removing the run dependencies on setuptools and wheel, which have not been required for a while. Our linter has asked us for the past two years to add setuptools to the host section, so I don't expect additional work on feedstocks from this change.

https://github.com/pypa/pip/tree/25.1

Address issue https://github.com/AnacondaRecipes/pip-feedstock/issues/36
Some .exe files are missing:
```
site-packages/pip/_vendor/distlib/t32.exe
site-packages/pip/_vendor/distlib/t64-arm.exe
site-packages/pip/_vendor/distlib/t64.exe
site-packages/pip/_vendor/distlib/w32.exe
site-packages/pip/_vendor/distlib/w64-arm.exe
site-packages/pip/_vendor/distlib/w64.exe
```