### PR TITLE
with_setuptools_wheel true for python 3.13 and below

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# todo: re-enable with_setuptools_wheel false once python 3.14 is released.
 with_setuptools_wheel:
   - true
-  - false
+#  - false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -19,20 +19,20 @@ build:
 
 requirements:
   host:
-    - python >=3.13.0a0                    # [not with_setuptools_wheel]
-    - python >=3.9,<3.13.0a0               # [with_setuptools_wheel]
+    - python >=3.14.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.14.0a0               # [with_setuptools_wheel]
     - setuptools
     - wheel
   run:
-    - python >=3.13.0a0                    # [not with_setuptools_wheel]
-    - python >=3.9,<3.13.0a0               # [with_setuptools_wheel]
+    - python >=3.14.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.14.0a0               # [with_setuptools_wheel]
     - setuptools                           # [with_setuptools_wheel]
     - wheel                                # [with_setuptools_wheel]
 
 test:
   requires:
     - python 3.9                           # [with_setuptools_wheel]
-    - python 3.13.0                        # [not with_setuptools_wheel]
+    - python 3.14.0                        # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list


### PR DESCRIPTION
with_setuptools_wheel true for python 3.13 and below

This will give more time to projects that missed specifying dependencies on setuptools.