### PR TITLE
Enable build without setuptools and wheels

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,3 @@
 with_setuptools_wheel:
   - true
   - false
-
-python:
-  - "3.10"
-  - "3.14"
-
-zip_keys:
-  - - python
-    - with_setuptools_wheel

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
 with_setuptools_wheel:
   - true
+  - false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,11 @@
 with_setuptools_wheel:
   - true
   - false
+
+python:
+  - "3.10"
+  - "3.14"
+
+zip_keys:
+  - - python
+    - with_setuptools_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,9 @@ requirements:
 
 test:
   requires:
-    - python
+    # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
+    - python 3.10                          # [with_setuptools_wheel]
+    - python 3.14.0                        # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,17 +20,20 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.15.0a0
+    - python >=3.14.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.14.0a0               # [with_setuptools_wheel]
     - flit-core >=3.11,<4
   run:
-    - python >=3.9,<3.15.0a0
-    - setuptools              # [with_setuptools_wheel]
-    - wheel                   # [with_setuptools_wheel]
+    - python >=3.14.0a0                    # [not with_setuptools_wheel]
+    - python >=3.9,<3.14.0a0               # [with_setuptools_wheel]
+    - setuptools                           # [with_setuptools_wheel]
+    - wheel                                # [with_setuptools_wheel]
 
 test:
   requires:
     # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
-    - python 3.10
+    - python 3.10                          # [with_setuptools_wheel]
+    - python 3.14.0                        # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -20,17 +20,17 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.15.0a0  # [with_setuptools_wheel]
+    - python >=3.9,<3.15.0a0
     - flit-core >=3.11,<4
   run:
-    - python >=3.9,<3.15.0a0  # [with_setuptools_wheel]
+    - python >=3.9,<3.15.0a0
     - setuptools              # [with_setuptools_wheel]
     - wheel                   # [with_setuptools_wheel]
 
 test:
   requires:
     # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
-    - python 3.10  # [with_setuptools_wheel]
+    - python 3.10
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
   requires:
     # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
     - python 3.10                          # [with_setuptools_wheel]
-    - python 3.14.0                        # [not with_setuptools_wheel]
+    - python 3.14                          # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,7 @@ requirements:
 
 test:
   requires:
-    # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
-    - python 3.10                          # [with_setuptools_wheel]
-    - python 3.14.0                        # [not with_setuptools_wheel]
+    - python
   commands:
     - pip -h
     - pip list


### PR DESCRIPTION
pip 26.0.1
**Destination channel:**  defaults

### Links

- [PKG-12904](https://anaconda.atlassian.net/browse/PKG-12904) 
- [Upstream repository](https://github.com/pypa/pip/tree/26.0.1)

### Explanation of changes:
- Enable build without setuptools and wheel
- New build number
- Build with fixed flit-core
- enable python for build without wheel

[PKG-12904]: https://anaconda.atlassian.net/browse/PKG-12904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ