### PR TITLE
drop Python 3.9 support for pip>=26.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,11 @@ build:
 requirements:
   host:
     - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.9,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
     - flit-core >=3.11,<4
   run:
     - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.9,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
     - setuptools  # [with_setuptools_wheel]
     - wheel  # [with_setuptools_wheel]
 


### PR DESCRIPTION
Fixes https://github.com/AnacondaRecipes/pip-feedstock/issues/51