### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -21,11 +21,11 @@ build:
 requirements:
   host:
     - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.9,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
     - flit-core >=3.11,<4
   run:
     - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.9,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
     - setuptools  # [with_setuptools_wheel]
     - wheel  # [with_setuptools_wheel]
 


### PR DESCRIPTION
Fix to match upstream python requirements. Paired with https://github.com/AnacondaRecipes/repodata-hotfixes/pull/321
