### PR TITLE
Update version to 26.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pip" %}
-{% set version = "26.1.1" %}
+{% set version = "26.1.2" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
+  sha256: f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
 
 build:
   noarch: python
-  number: 1
+  number: 0
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main


### PR DESCRIPTION
pip 26.1.2
**Destination channel:**  defaults

### Links

- [PKG-15841](https://anaconda.atlassian.net/browse/PKG-15841) 
- [Upstream repository](https://github.com/pypa/pip/tree/26.1.2)

### Explanation of changes:
- New version number


[PKG-15841]: https://anaconda.atlassian.net/browse/PKG-15841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ