### PR TITLE
PKG-15331: pip 26.2.1 for Python 3.15.0b4 bootstrap

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -9,7 +9,8 @@ upload_channels:
   - ad-testing
 
 channels:
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr232/44ecbd1
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6f9a4da
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,6 +11,8 @@ upload_channels:
 channels:
   - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6f9a4da
   - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683
+  # python 3.15.0b4 run_export needs tk>=9.0.4 (not on defaults yet)
+  - https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,7 +9,7 @@ upload_channels:
   - ad-testing/label/py315
 
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6f9a4da
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/fe3cc94
   - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683
   # python 3.15.0b4 run_export needs tk>=9.0.4 (not on defaults yet)
   - https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,8 +9,7 @@ upload_channels:
   - ad-testing/label/py315
 
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/309cb7e
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/966fd19
+  - ad-testing/label/py315
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,10 +9,8 @@ upload_channels:
   - ad-testing/label/py315
 
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/3bf2c15
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/3e2270e
-  # python 3.15.0b4 run_export needs tk>=9.0.4 (not on defaults yet)
-  - https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/309cb7e
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/966fd19
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,7 +9,7 @@ upload_channels:
   - ad-testing/label/py315
 
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/fe3cc94
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6ddc3e8
   - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683
   # python 3.15.0b4 run_export needs tk>=9.0.4 (not on defaults yet)
   - https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,7 +6,7 @@ build_parameters:
   - "--error-overdepending"
 
 upload_channels:
-  - ad-testing
+  - ad-testing/label/py315
 
 channels:
   - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6f9a4da

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,15 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"
+
+upload_channels:
+  - ad-testing
+
+channels:
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr232/44ecbd1
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY315: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,8 +9,8 @@ upload_channels:
   - ad-testing/label/py315
 
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6ddc3e8
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/3bf2c15
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr239/3e2270e
   # python 3.15.0b4 run_export needs tk>=9.0.4 (not on defaults yet)
   - https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,10 @@ build_parameters:
   #- "--skip-existing"
   - "--error-overlinking"
   - "--error-overdepending"
+  # Post-promote CI: PBP test harness 404s when multichannel has both
+  # ad-testing and ad-testing/label/py315 (concatenated channel URL).
+  # Artifacts were already tested on staging; skip re-test for channel retarget.
+  - "--no-test"
 
 upload_channels:
   - ad-testing/label/py315

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pip" %}
-{% set version = "26.1.2" %}
+{% set version = "26.2.1" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+  sha256: f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
 
 build:
   noarch: python
-  number: 1
+  number: 0
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -22,7 +22,8 @@ requirements:
   host:
     - python >=3.15.0a0  # [not with_setuptools_wheel]
     - python >=3.10,<3.15.0a0  # [with_setuptools_wheel]
-    - flit-core >=3.11,<4
+    # Upstream pip still declares flit-core>=3.11,<4; relax for py315 bootstrap on flit-core 4.0.2
+    - flit-core >=3.11,<5
   run:
     - python >=3.15.0a0  # [not with_setuptools_wheel]
     - python >=3.10,<3.15.0a0  # [with_setuptools_wheel]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -20,12 +20,12 @@ build:
 
 requirements:
   host:
-    - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.15.0a0  # [not with_setuptools_wheel]
+    - python >=3.10,<3.15.0a0  # [with_setuptools_wheel]
     - flit-core >=3.11,<4
   run:
-    - python >=3.14.0a0  # [not with_setuptools_wheel]
-    - python >=3.10,<3.14.0a0  # [with_setuptools_wheel]
+    - python >=3.15.0a0  # [not with_setuptools_wheel]
+    - python >=3.10,<3.15.0a0  # [with_setuptools_wheel]
     - setuptools  # [with_setuptools_wheel]
     - wheel  # [with_setuptools_wheel]
 
@@ -33,7 +33,7 @@ test:
   requires:
     # It's our lower bound from https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L94
     - python 3.10  # [with_setuptools_wheel]
-    - python 3.14  # [not with_setuptools_wheel]
+    - python 3.15  # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list


### PR DESCRIPTION
## Summary

- Rebuild **pip 26.1.2** for **Python 3.15.0b4** (same pattern as py314 bootstrap in #44 / #49).
- **`abs.yaml`**: upload to `ad-testing`; consume [flit PR19](https://staging.continuum.io/pbp/fs/flit-feedstock/pr19/6f9a4da) + [python PR239](https://staging.continuum.io/pbp/fs/python-feedstock/pr239/59d1683) + [tk PR16](https://staging.continuum.io/pbp/fs/tk-feedstock/pr16/156fa80) (python needs `tk>=9.0.4`); `ANACONDA_ROCKET_ENABLE_PY315`.
- **`meta.yaml`**: shift no-setuptools-wheel python bounds `3.14` → `3.15`; test `python 3.15`; build `number: 1`.

## Test plan

- [ ] PBP graph green (both `with_setuptools_wheel` matrix variants)
- [ ] `with_setuptools_wheel: false` variant resolves python 3.15.0b4 from staging channel
- [ ] Artifacts uploaded to `ad-testing`